### PR TITLE
Upper bound hashable dependency

### DIFF
--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -45,7 +45,7 @@ library
   hs-source-dirs: src
   build-depends:  base                 >= 4.7 && < 5
                 , containers           >= 0.6.2 && < 0.7
-                , hashable             >= 1.3.0 && < 1.4
+                , hashable             >= 1.3.0 && < 1.3.4
                 , process              >= 1.6.9 && < 1.7
                 , parsec               >= 3.1.14 && < 3.2
                 , mtl                  >= 2.2.2 && < 2.3


### PR DESCRIPTION
Rest does not build with `hashable-1.3.4.1`, it gives error 

```
src/Language/REST/Types.hs:72:10: error:
    Duplicate instance declarations:
      instance Hashable a => Hashable (OS.Set a)
        -- Defined at src/Language/REST/Types.hs:72:10
      instance Hashable v => Hashable (OS.Set v)
        -- Defined in ‘hashable-1.3.4.1:Data.Hashable.Class’
   |
72 | instance Hashable a => Hashable (OS.Set a) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Language/REST/Types.hs:75:10: error:
    Duplicate instance declarations:
      instance (Hashable a, Hashable b) => Hashable (M.Map a b)
        -- Defined at src/Language/REST/Types.hs:75:10
      instance (Hashable k, Hashable v) => Hashable (M.Map k v)
        -- Defined in ‘hashable-1.3.4.1:Data.Hashable.Class’
   |
75 | instance (Hashable a, Hashable b) => Hashable (M.Map a b) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ```