### PR TITLE
Add upper bound to unordered-containers

### DIFF
--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -47,6 +47,8 @@ library
     Language.REST.PartialOrder
     Language.REST.Rewrite
     Language.REST.WQO
+    Language.REST.Util
+
 
   hs-source-dirs: src
   build-depends:  base                 >= 4.7 && < 5

--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -55,7 +55,7 @@ library
                 , process              >= 1.6.9 && < 1.7
                 , parsec               >= 3.1.14 && < 3.2
                 , mtl                  >= 2.2.2 && < 2.3
-                , unordered-containers >= 0.2.13 && < 0.3
+                , unordered-containers >= 0.2.13 && < 0.2.14
                 , text                 >= 1.2.4 && < 1.3
 
 Test-Suite test-rest

--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -103,6 +103,7 @@ Test-Suite test-rest
     Language.REST.Types
     Language.REST.WorkStrategy
     Language.REST.WQO
+    Language.REST.Util
     Language.REST.SMT
     LazyOC
     MultisetOrder
@@ -169,6 +170,7 @@ executable rest
       Language.REST.SMT
       Language.REST.Types
       Language.REST.WQO
+      Language.REST.Util
       Language.REST.WorkStrategy
       Lists
       Multiset


### PR DESCRIPTION
Hi @zgrannan -- am adding this upper bound to the cabal so it builds with `cabal v2-build` as well. Thanks! 