### PR TITLE
Relax upper bounds: Hashable, MTL, Text, Time

### DIFF
--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -53,7 +53,7 @@ library
   hs-source-dirs: src
   build-depends:  base                 >= 4.7 && < 5
                 , containers           >= 0.6.2 && < 0.7
-                , hashable             >= 1.3.0 && < 1.4
+                , hashable             >= 1.3.0 && < 1.5
                 , process              >= 1.6.9 && < 1.7
                 , parsec               >= 3.1.14 && < 3.2
                 , mtl                  >= 2.2.2 && < 2.3

--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -56,7 +56,7 @@ library
                 , hashable             >= 1.3.0 && < 1.5
                 , process              >= 1.6.9 && < 1.7
                 , parsec               >= 3.1.14 && < 3.2
-                , mtl                  >= 2.2.2 && < 2.3
+                , mtl                  >= 2.2.2 && < 2.4
                 , unordered-containers >= 0.2.13 && < 0.3
                 , text                 >= 1.2.4 && < 2.1
 

--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -73,7 +73,7 @@ library testlib
                 , monad-loops >= 0.4.3 && < 0.5
                 , unordered-containers >= 0.2.11
                 , text
-                , time >= 1.9.3 && < 1.10
+                , time >= 1.9.3 && < 1.13
   exposed-modules:
       Arith
       DSL
@@ -124,7 +124,7 @@ Test-Suite rest
                 , unordered-containers >= 0.2.11
                 , testlib
                 , text
-                , time >= 1.9.3 && < 1.10
+                , time
                 -- , liquidhaskell
                 -- , liquid-base
   other-modules:

--- a/rest-rewrite.cabal
+++ b/rest-rewrite.cabal
@@ -58,7 +58,7 @@ library
                 , parsec               >= 3.1.14 && < 3.2
                 , mtl                  >= 2.2.2 && < 2.3
                 , unordered-containers >= 0.2.13 && < 0.3
-                , text                 >= 1.2.4 && < 1.3
+                , text                 >= 1.2.4 && < 2.1
 
 library testlib
   default-language:  Haskell2010
@@ -72,7 +72,7 @@ library testlib
                 , mtl
                 , monad-loops >= 0.4.3 && < 0.5
                 , unordered-containers >= 0.2.11
-                , text >= 1.2.2
+                , text
                 , time >= 1.9.3 && < 1.10
   exposed-modules:
       Arith
@@ -123,7 +123,7 @@ Test-Suite rest
                 , mtl
                 , unordered-containers >= 0.2.11
                 , testlib
-                , text >= 1.2.2
+                , text
                 , time >= 1.9.3 && < 1.10
                 -- , liquidhaskell
                 -- , liquid-base

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,6 +8,7 @@ module Main where
 
 import qualified Data.List as L
 import Data.Hashable
+import Control.Monad (guard)
 import Control.Monad.Identity
 import qualified Arith as A
 


### PR DESCRIPTION
The latest versions of these packages on hackage are:

* `hashable-1.4.1.0`
* `mtl-2.3`
* `text-2.0.1`
* `time-1.12.2`

`time` has a `1.13` version release, but it has a base bound of `<0`, so I presume `1.12.2` is the intended latest.

These all appear to be upgradeable (builds and tests pass, at least).

Technically all of these could be done with revisions, though the tests will fail to compile with `mtl`'s update since 2.3 no longer exports `guard`, hence the PR. Let me know if you'd prefer that instead and I can close this. Thanks!